### PR TITLE
Added Rule error identifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "^1.10.50"
+        "phpstan/phpstan": "^1.10.50",
+        "nikic/php-parser": "^4"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.3",

--- a/src/Rules/ClassDependencyTreeRule.php
+++ b/src/Rules/ClassDependencyTreeRule.php
@@ -113,15 +113,12 @@ final readonly class ClassDependencyTreeRule implements Rule
     private function resolveParameterTypeClass(ParameterReflection $parameterReflection): ?Class_
     {
         $parameterType = $parameterReflection->getType();
-        if (! $parameterType instanceof TypeWithClassName) {
+        $classReflections = $parameterType->getObjectClassReflections();
+        // XXX add support for union types
+        if (count($classReflections) !== 1) {
             return null;
         }
 
-        $parameterClassReflection = $parameterType->getClassReflection();
-        if (! $parameterClassReflection instanceof ClassReflection) {
-            return null;
-        }
-
-        return $this->classReflectionParser->parse($parameterClassReflection);
+        return $this->classReflectionParser->parse($classReflections[0]);
     }
 }

--- a/src/Rules/ClassDependencyTreeRule.php
+++ b/src/Rules/ClassDependencyTreeRule.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\TypeWithClassName;
 use TomasVotruba\CognitiveComplexity\AstCognitiveComplexityAnalyzer;
 use TomasVotruba\CognitiveComplexity\ClassReflectionParser;
@@ -89,13 +90,13 @@ final readonly class ClassDependencyTreeRule implements Rule
             return [];
         }
 
-        return [
-            sprintf(
-                self::ERROR_MESSAGE,
-                $totaDependencyTreeComplexity,
-                $this->configuration->getMaxDependencyTreeComplexity()
-            ),
-        ];
+        $message = sprintf(
+            self::ERROR_MESSAGE,
+            $totaDependencyTreeComplexity,
+            $this->configuration->getMaxDependencyTreeComplexity()
+        );
+
+        return [RuleErrorBuilder::message($message)->identifier('complexity.dependencyTree')->build()];
     }
 
     private function isTypeToAnalyse(ClassReflection $classReflection): bool

--- a/src/Rules/ClassLikeCognitiveComplexityRule.php
+++ b/src/Rules/ClassLikeCognitiveComplexityRule.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use TomasVotruba\CognitiveComplexity\AstCognitiveComplexityAnalyzer;
 use TomasVotruba\CognitiveComplexity\Configuration;
 
@@ -39,7 +40,6 @@ final readonly class ClassLikeCognitiveComplexityRule implements Rule
 
     /**
      * @param InClassNode $node
-     * @return string[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -59,6 +59,6 @@ final readonly class ClassLikeCognitiveComplexityRule implements Rule
             $this->configuration->getMaxClassCognitiveComplexity()
         );
 
-        return [$message];
+        return [RuleErrorBuilder::message($message)->identifier('complexity.classLike')->build()];
     }
 }

--- a/src/Rules/FunctionLikeCognitiveComplexityRule.php
+++ b/src/Rules/FunctionLikeCognitiveComplexityRule.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use TomasVotruba\CognitiveComplexity\AstCognitiveComplexityAnalyzer;
 use TomasVotruba\CognitiveComplexity\Configuration;
 use TomasVotruba\CognitiveComplexity\Exception\ShouldNotHappenException;
@@ -53,7 +54,6 @@ final readonly class FunctionLikeCognitiveComplexityRule implements Rule
 
     /**
      * @param FunctionLike $node
-     * @return string[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -75,7 +75,7 @@ final readonly class FunctionLikeCognitiveComplexityRule implements Rule
             $this->configuration->getMaxFunctionCognitiveComplexity()
         );
 
-        return [$message];
+        return [RuleErrorBuilder::message($message)->identifier('complexity.functionLike')->build()];
     }
 
     private function resolveFunctionName(FunctionLike $functionLike, Scope $scope): string


### PR DESCRIPTION
eases migration to PHPStan 2.x while staying compatible with PHPStan 1.x for now