### PR TITLE
Fix type error when running inside PHPStan phar context

### DIFF
--- a/src/NodeVisitor/ComplexityNodeVisitor.php
+++ b/src/NodeVisitor/ComplexityNodeVisitor.php
@@ -17,8 +17,15 @@ final class ComplexityNodeVisitor extends NodeVisitorAbstract
     ) {
     }
 
-    public function enterNode(Node $node): ?Node
+    /**
+     * @param Node|int $node On PHP 8.5 with php-parser v5, BackedEnumCase values may be passed as int
+     */
+    public function enterNode(Node|int $node): ?Node
     {
+        if (! $node instanceof Node) {
+            return null;
+        }
+
         if (! $this->complexityAffectingNodeFinder->isIncrementingNode($node)) {
             return null;
         }

--- a/src/NodeVisitor/NestingNodeVisitor.php
+++ b/src/NodeVisitor/NestingNodeVisitor.php
@@ -48,8 +48,15 @@ final class NestingNodeVisitor extends NodeVisitorAbstract
         $this->measuredNestingLevel = 1;
     }
 
-    public function enterNode(Node $node): ?Node
+    /**
+     * @param Node|int $node On PHP 8.5 with php-parser v5, BackedEnumCase values may be passed as int
+     */
+    public function enterNode(Node|int $node): ?Node
     {
+        if (! $node instanceof Node) {
+            return null;
+        }
+
         if ($this->isNestingNode($node)) {
             ++$this->measuredNestingLevel;
         }
@@ -75,8 +82,15 @@ final class NestingNodeVisitor extends NodeVisitorAbstract
         return null;
     }
 
-    public function leaveNode(Node $node): ?Node
+    /**
+     * @param Node|int $node On PHP 8.5 with php-parser v5, BackedEnumCase values may be passed as int
+     */
+    public function leaveNode(Node|int $node): ?Node
     {
+        if (! $node instanceof Node) {
+            return null;
+        }
+
         if ($this->isNestingNode($node)) {
             --$this->measuredNestingLevel;
         }

--- a/src/Rules/ClassDependencyTreeRule.php
+++ b/src/Rules/ClassDependencyTreeRule.php
@@ -101,7 +101,7 @@ final readonly class ClassDependencyTreeRule implements Rule
     private function isTypeToAnalyse(ClassReflection $classReflection): bool
     {
         foreach ($this->configuration->getDependencyTreeTypes() as $dependencyTreeType) {
-            if ($classReflection->isSubclassOf($dependencyTreeType)) {
+            if ($classReflection->isSubclassOfClass($dependencyTreeType)) {
                 return true;
             }
         }

--- a/src/Rules/ClassDependencyTreeRule.php
+++ b/src/Rules/ClassDependencyTreeRule.php
@@ -11,6 +11,7 @@ use PHPStan\Node\InClassNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use TomasVotruba\CognitiveComplexity\AstCognitiveComplexityAnalyzer;
@@ -30,7 +31,8 @@ final readonly class ClassDependencyTreeRule implements Rule
     public function __construct(
         private AstCognitiveComplexityAnalyzer $astCognitiveComplexityAnalyzer,
         private ClassReflectionParser $classReflectionParser,
-        private Configuration $configuration
+        private Configuration $configuration,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 
@@ -101,7 +103,12 @@ final readonly class ClassDependencyTreeRule implements Rule
     private function isTypeToAnalyse(ClassReflection $classReflection): bool
     {
         foreach ($this->configuration->getDependencyTreeTypes() as $dependencyTreeType) {
-            if ($classReflection->isSubclassOfClass($dependencyTreeType)) {
+            if (! $this->reflectionProvider->hasClass($dependencyTreeType)) {
+                continue;
+            }
+
+            $dependencyTreeClassReflection = $this->reflectionProvider->getClass($dependencyTreeType);
+            if ($classReflection->isSubclassOfClass($dependencyTreeClassReflection)) {
                 return true;
             }
         }

--- a/tests/AstCognitiveComplexityAnalyzer/AstCognitiveComplexityAnalyzerTest.php
+++ b/tests/AstCognitiveComplexityAnalyzer/AstCognitiveComplexityAnalyzerTest.php
@@ -51,6 +51,7 @@ final class AstCognitiveComplexityAnalyzerTest extends TestCase
         yield [__DIR__ . '/Fixture/interface_0.php.inc', 0];
         yield [__DIR__ . '/Fixture/for_7.php.inc', 7];
         yield [__DIR__ . '/Fixture/ternary_3.php.inc', 3];
+        yield [__DIR__ . '/Fixture/backed_enum_0.php.inc', 0];
     }
 
     private function parseFileToFirstFunctionLike(string $fileContent): ClassMethod | Function_

--- a/tests/AstCognitiveComplexityAnalyzer/Fixture/backed_enum_0.php.inc
+++ b/tests/AstCognitiveComplexityAnalyzer/Fixture/backed_enum_0.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+enum Status: int
+{
+    case Active = 1;
+    case Inactive = 0;
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Active => 'Active',
+            self::Inactive => 'Inactive',
+        };
+    }
+}

--- a/tests/Rules/FunctionLikeCognitiveComplexityRule/Fixture/BackedEnumWithMethod.php
+++ b/tests/Rules/FunctionLikeCognitiveComplexityRule/Fixture/BackedEnumWithMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\CognitiveComplexity\Tests\Rules\FunctionLikeCognitiveComplexityRule\Fixture;
+
+enum BackedEnumWithMethod: string
+{
+    case Admin = 'admin';
+    case User = 'user';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Admin => 'Administrator',
+            self::User => 'Regular User',
+        };
+    }
+}

--- a/tests/Rules/FunctionLikeCognitiveComplexityRule/FunctionLikeCognitiveComplexityRuleTest.php
+++ b/tests/Rules/FunctionLikeCognitiveComplexityRule/FunctionLikeCognitiveComplexityRuleTest.php
@@ -44,6 +44,9 @@ final class FunctionLikeCognitiveComplexityRuleTest extends RuleTestCase
             8
         );
         yield [__DIR__ . '/Fixture/VideoRepository.php', [[$errorMessage, 12]]];
+
+        // backed enum with method should not crash (PHP 8.5 compat)
+        yield [__DIR__ . '/Fixture/BackedEnumWithMethod.php', []];
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #14

## Problem

When `cognitive-complexity` runs inside PHPStan's execution context, it creates its own `NodeTraverser` (via `ComplexityNodeTraverserFactory`). This traverser uses PHPStan's **phar-bundled php-parser**, which in certain cases passes non-`Node` values (e.g., raw `int`) to `enterNode()`/`leaveNode()`, causing a fatal type error:

```
Internal error: ComplexityNodeVisitor::enterNode(): Argument #1 ($node)
must be of type PhpParser\Node, int given,
called in phpstan.phar/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php on line 171
```

This occurs on files without enums (e.g., `AppServiceProvider.php`, migration files), confirming the issue is not specific to `BackedEnumCase` as originally reported in #14.

**Key finding**: The project's own `vendor/nikic/php-parser` (v5.7.0) has proper guards, but PHPStan's phar bundles a different version whose `traverseArray()` does not fully prevent non-Node values from reaching visitors.

Tested with PHPStan 2.1.40 and 2.1.42 (latest) — both reproduce the issue.

## Fix

Add type guards (`Node|int` union type + early return) in:
- `ComplexityNodeVisitor::enterNode()`
- `NestingNodeVisitor::enterNode()`
- `NestingNodeVisitor::leaveNode()`

PHP `^8.3` is already required, so union types are available.

## Tests

- Added `backed_enum_0.php.inc` fixture (int-backed enum with method) to `AstCognitiveComplexityAnalyzerTest`
- Added `BackedEnumWithMethod.php` fixture to `FunctionLikeCognitiveComplexityRuleTest`
- All 15 tests pass